### PR TITLE
Changed: Rollback Uno issue 20669 fix as android build crahses after …

### DIFF
--- a/.github/Install-WindowsSdkISO.ps1
+++ b/.github/Install-WindowsSdkISO.ps1
@@ -251,7 +251,7 @@ if ($InstallWindowsSDK)
     if($buildNumber -eq 19041)
     {
         # Workaround for missing SDK
-        $uri = "https://software-static.download.prss.microsoft.com/pr/download/19041.685.201201-2105.vb_release_svc_prod1_WindowsSDK.iso";
+        $uri = "https://go.microsoft.com/fwlink/?linkid=2120735";
     }
 
     if ($env:TEMP -eq $null)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,4 +17,12 @@
     <PackageVersion Include="CommunityToolkit.WinUI.UI" Version="7.1.2" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- Fix for https://github.com/unoplatform/uno/issues/21923 -->
+    <UnoHotDesignVersion>1.18.0-dev.330</UnoHotDesignVersion>
+
+    <!-- Disable XAML Hot Design -->
+    <UseDesignerContext>false</UseDesignerContext>
+    <EnableXamlHotDesigner>false</EnableXamlHotDesigner>
+  </PropertyGroup>
 </Project>

--- a/RoMi/RoMi.csproj
+++ b/RoMi/RoMi.csproj
@@ -56,18 +56,18 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug' And $(TargetFramework.Contains('android'))">
-    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
-    <AndroidKeyStore>False</AndroidKeyStore>
-    <AndroidUseAapt2>True</AndroidUseAapt2>
+    <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
+    <AndroidKeyStore>false</AndroidKeyStore>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>
 
   <PropertyGroup  Condition="'$(Configuration)'=='Release' And $(TargetFramework.Contains('android'))">
-    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidCreatePackagePerAbi>false</AndroidCreatePackagePerAbi>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
-    <AndroidKeyStore>False</AndroidKeyStore>
+    <AndroidKeyStore>false</AndroidKeyStore>
+    <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidLinkTool>r8</AndroidLinkTool>
-    <AndroidUseAapt2>True</AndroidUseAapt2>
   </PropertyGroup>
 
    <!--

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "msbuild-sdks": {
     //"Uno.Sdk": "6.4.24",
-    "Uno.Sdk": "6.5.0-dev.100" // Fixes for https://github.com/unoplatform/uno/issues/21923 and https://github.com/unoplatform/uno/issues/20669
+    "Uno.Sdk": "6.5.0-dev.43" // Fix for https://github.com/unoplatform/uno/issues/21923
   },
   "sdk": {
     "version": "10.0.100",


### PR DESCRIPTION
With Uno.Sdk 6.5.0-dev.100 the android build crashes instantly after start of app.
Roll back to Uno.Sdk  6.5.0-dev.43 to only fix [Issue 21923](https://github.com/unoplatform/uno/issues/21923)